### PR TITLE
Update gitignore and Fix typo for EnvConfig in main_prod.dart file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Miscellaneous
 *.class
-*.lock
 *.log
 *.pyc
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Miscellaneous
 *.class
+*.lock
 *.log
 *.pyc
 *.swp
@@ -95,3 +96,7 @@ build/
 
 # Local configuration file (sdk path, etc)
 local.properties
+
+# Flutter version manager related
+.fvm/
+.fvm/*

--- a/lib/main_prod.dart
+++ b/lib/main_prod.dart
@@ -5,7 +5,7 @@ import 'package:flutter_getx_template/flavors/env_config.dart';
 import 'package:flutter_getx_template/flavors/environment.dart';
 
 void main() {
-  EnvConfig devConfig = EnvConfig(
+  EnvConfig prodConfig = EnvConfig(
     appName: "Flutter GetX Template Prod",
     baseUrl: "https://api.github.com",
     shouldCollectCrashLog: true,
@@ -13,7 +13,7 @@ void main() {
 
   BuildConfig.instantiate(
     envType: Environment.PRODUCTION,
-    envConfig: devConfig,
+    envConfig: prodConfig,
   );
 
   runApp(const MyApp());


### PR DESCRIPTION
Added `Flutter Version Management` related entries in the `.gitignore` file in case a programmer decides to write code for this repo while having multiple flutter versions in his/her system.

And changed a variable name in `main_prod.dart` which may be was copied from `main_dev.dart`. The new variable name is more suited to the prod main file as my judgment.